### PR TITLE
Pull request for handling Custom Date Range click events in case it's not set

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1126,7 +1126,9 @@
                 target.closest(this.container).length ||
                 target.closest('.calendar-table').length
                 ) return;
-            this.hide();
+            this.container.removeClass('show-calendar');
+            this.element.trigger('hideCalendar.daterangepicker', this);
+            setTimeout(this.hide.bind(this), 0);
         },
 
         showCalendars: function() {
@@ -1356,6 +1358,8 @@
             this.endDate = this.oldEndDate;
             this.hide();
             this.element.trigger('cancel.daterangepicker', this);
+            this.container.removeClass('show-calendar');
+            this.element.trigger('hideCalendar.daterangepicker', this);
         },
 
         monthOrYearChanged: function(e) {


### PR DESCRIPTION
When the user clicks the 'Custom' calendar option and clicks outside or cancel button, then also in the next daterange picker visit, the calendar is shown as if user has selected Custom date range in the last visit, though the actual highlighted calendar option is different (like 'Today', 'Yesterday' etc.)
